### PR TITLE
fix(createStatsDClient): Return full StatsD type

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ These tags are consistent with tags sent by [Gantry](https://github.com/SEEK-Job
 This is intended for containerized services, particularly those deployed with [Gantry](https://github.com/SEEK-Jobs/gantry).
 
 ```typescript
+import { StatsD } from 'hot-shots';
 import { createStatsDClient } from 'seek-datadog-custom-metrics';
 
 // Expects `name`, `version`, `environment` and `metricsServer` properties
@@ -55,7 +56,7 @@ const errorHandler = (err: Error) => {
 };
 
 // Returns a standard hot-shots StatsD instance
-const metricsClient = createStatsDClient(config, errorHandler);
+const metricsClient = createStatsDClient(StatsD, config, errorHandler);
 ```
 
 ### `createCloudWatchClient`

--- a/src/createStatsDClient.test.ts
+++ b/src/createStatsDClient.test.ts
@@ -1,9 +1,15 @@
+import { StatsD } from 'hot-shots';
+
 import createStatsDClient from './createStatsDClient';
 
 describe('createStatsDClient', () => {
   it('should create a new mock client', () => {
     expect(
-      createStatsDClient({ name: 'test', environment: 'jest', version: '0' }),
+      createStatsDClient(StatsD, {
+        name: 'test',
+        environment: 'jest',
+        version: '0',
+      }),
     ).toBeInstanceOf(Object);
   });
 });

--- a/src/createTimedSpan.test.ts
+++ b/src/createTimedSpan.test.ts
@@ -1,7 +1,9 @@
+import { StatsD } from 'hot-shots';
+
 import createStatsDClient from './createStatsDClient';
 import createTimedSpan from './createTimedSpan';
 
-const metricsClient = createStatsDClient({
+const metricsClient = createStatsDClient(StatsD, {
   name: 'jest',
   version: '0.0.1',
   environment: 'dev',


### PR DESCRIPTION
BREAKING CHANGE: the `StatsD` class must be passed as the first argument of the factory function. The return type will reflect the input type, so you don't need to perform a type assertion `as StatsD` anymore.

```diff
import { StatsD } from 'hot-shots';
import { createStatsDClient } from 'seek-datadog-custom-metrics';

- export const metricsClient = createStatsDClient(config, errHandler) as StatsD;
+ export const metricsClient = createStatsDClient(StatsD, config, errHandler);
```