### PR TITLE
docs: Deprecate `createCloudWatchClient`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@
 [![npm package](https://img.shields.io/npm/v/seek-datadog-custom-metrics)](https://www.npmjs.com/package/seek-datadog-custom-metrics)
 [![Powered by skuba](https://img.shields.io/badge/🤿%20skuba-powered-009DC4)](https://github.com/seek-oss/skuba)
 
-Common interface for sending [Datadog custom metrics](https://docs.datadoghq.com/developers/metrics/custom_metrics/) from Node.js runtime environments:
-
-- Containers (via [hot-shots](https://github.com/brightcove/hot-shots))
-- AWS Lambda (via [Datadog's CloudWatch integration](https://docs.datadoghq.com/integrations/amazon_lambda/#using-cloudwatch-logs))
+Helpers for sending [Datadog custom metrics](https://docs.datadoghq.com/developers/metrics/custom_metrics/) via [hot-shots](https://github.com/brightcove/hot-shots).
 
 ```shell
 yarn add seek-datadog-custom-metrics
@@ -20,7 +17,6 @@ yarn add seek-datadog-custom-metrics
 - [Tagging convention](#tagging-convention)
 - [API reference](#api-reference)
   - [createStatsDClient](#createstatsdclient)
-  - [createCloudWatchClient](#createcloudwatchclient)
   - [createNoOpClient](#createnoopclient)
   - [createTimedSpan](#createtimedspan)
 - [Contributing](https://github.com/seek-oss/datadog-custom-metrics/blob/master/CONTRIBUTING.md)
@@ -57,21 +53,6 @@ const errorHandler = (err: Error) => {
 
 // Returns a standard hot-shots StatsD instance
 const metricsClient = createStatsDClient(StatsD, config, errorHandler);
-```
-
-### `createCloudWatchClient`
-
-`createCloudWatchClient` returns a client that uses [Datadog's CloudWatch integration](https://docs.datadoghq.com/integrations/amazon_lambda/#using-cloudwatch-logs).
-This is intended for use in Lambda functions.
-
-```typescript
-import { createCloudWatchClient } from 'seek-datadog-custom-metrics';
-
-// Expects `name`, `version` and `environment` properties
-import config from '../config';
-
-// Returns a `MetricsClient` subset of the full StatsD interface
-const metricsClient = createCloudWatchClient(config);
 ```
 
 ### `createNoOpClient`

--- a/src/MetricsClient.ts
+++ b/src/MetricsClient.ts
@@ -1,9 +1,9 @@
 /**
  * Abstract interface for recording metrics
  *
- * This covers both the StatsD and CloudWatch clients. This is intended for
- * libraries that need to abstract over the two client types. Applications
- * using StatsD can use the richer `StatsD` type from `hot-shots` instead.
+ * This was intended to cover both the StatsD and CloudWatch clients. As the
+ * CloudWatch client type is now deprecated, consumers can use the richer
+ * `StatsD` type from `hot-shots` instead.
  */
 export default interface MetricsClient {
   /**

--- a/src/createCloudWatchClient.ts
+++ b/src/createCloudWatchClient.ts
@@ -17,11 +17,12 @@ const sanitiseTag = (tag: string): string => tag.replace(/\||@|,/g, '_');
 /**
  * Creates a new CloudWatch Datadog client configured for the given app
  *
- * This depends on Datadog's AWS Lambda integration. The returned client is
- * configured to use a common tagging convention based on the application's
- * name, environment and version.
+ * @deprecated This depends on Datadog's deprecated CloudWatch log integration.
+ * This has been superseded by the Datadog Lambda Extension which does not
+ * support the `count` metric type required by our `MetricClient` interface.
  *
- * @see {@link https://docs.datadoghq.com/integrations/amazon_lambda/#using-cloudwatch-logs}
+ * @see {@link https://docs.datadoghq.com/serverless/libraries_integrations/extension/}
+ * @see {@link https://docs.datadoghq.com/serverless/custom_metrics/#deprecated-cloudwatch-logs}
  *
  * @param config - Application configuration
  */


### PR DESCRIPTION
Our CloudWatch client depended on Datadog's deprecated CloudWatch log integration.

The CloudWatch log integration has been superseded by the Datadog Lambda Extension which does not support the `count` metric type required by our `MetricClient` interface. This prevents us from simply adding a new e.g. `createLambdaExtensionClient` function to replace it.

SEEK's Datadog customer account has the CloudWatch log integration enabled for backwards compatibility so this shouldn't break our existing codebases. This is more to discourage adding new consumers of the deprecated integration.
