### PR TITLE
feat(createLambdaExtensionClient): Allow metrics propagation via Datadog Lambda Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,6 @@ Helpers for sending [Datadog custom metrics](https://docs.datadoghq.com/develope
 yarn add seek-datadog-custom-metrics
 ```
 
-## Table of contents
-
-- [🐶 Datadog Custom Metrics](#-datadog-custom-metrics)
-  - [Table of contents](#table-of-contents)
-  - [Tagging convention](#tagging-convention)
-  - [API reference](#api-reference)
-    - [`createStatsDClient`](#createstatsdclient)
-    - [`createLambdaExtensionClient`](#createlambdaextensionclient)
-    - [`createNoOpClient`](#createnoopclient)
-    - [`createTimedSpan`](#createtimedspan)
-    - [`httpTracingConfig`](#httptracingconfig)
-
 ## Tagging convention
 
 All custom metrics are prefixed by `AppConfig.name`.

--- a/README.md
+++ b/README.md
@@ -63,21 +63,19 @@ import config from '../config';
 const { metricsClient, withLambdaExtension } =
   createLambdaExtensionClient(config);
 
-export const handler = withLambdaExtension(
-  (event, _ctx) => {
-    try {
-      logger.info('request');
+export const handler = withLambdaExtension((event, _ctx) => {
+  try {
+    logger.info('request');
 
-      await lambdaFunction(event);
-    } catch (err) {
-      logger.error({ err }, 'request');
+    await lambdaFunction(event);
+  } catch (err) {
+    logger.error({ err }, 'request');
 
-      metricsClient.increment('invocation_error');
+    metricsClient.increment('invocation_error');
 
-      throw new Error('invoke error');
-    }
-  },
-);
+    throw new Error('invoke error');
+  }
+});
 ```
 
 ### `createNoOpClient`

--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ yarn add seek-datadog-custom-metrics
 
 ## Table of contents
 
-- [Tagging convention](#tagging-convention)
-- [API reference](#api-reference)
-  - [createStatsDClient](#createstatsdclient)
-  - [createNoOpClient](#createnoopclient)
-  - [createTimedSpan](#createtimedspan)
-  - [httpTracingConfig](#httptracingconfig)
-- [Contributing](https://github.com/seek-oss/datadog-custom-metrics/blob/master/CONTRIBUTING.md)
+- [🐶 Datadog Custom Metrics](#-datadog-custom-metrics)
+  - [Table of contents](#table-of-contents)
+  - [Tagging convention](#tagging-convention)
+  - [API reference](#api-reference)
+    - [`createStatsDClient`](#createstatsdclient)
+    - [`createLambdaExtensionClient`](#createlambdaextensionclient)
+    - [`createNoOpClient`](#createnoopclient)
+    - [`createTimedSpan`](#createtimedspan)
+    - [`httpTracingConfig`](#httptracingconfig)
 
 ## Tagging convention
 
@@ -54,6 +56,40 @@ const errorHandler = (err: Error) => {
 
 // Returns a standard hot-shots StatsD instance
 const metricsClient = createStatsDClient(StatsD, config, errorHandler);
+```
+
+### `createLambdaExtensionClient`
+
+`createLambdaExtensionClient` creates a [lambda extension](https://docs.datadoghq.com/serverless/libraries_integrations/extension/) client.
+This is intended for AWS Lambda functions and is a replacement for `createCloudWatchClient`.
+
+This client will only submit metrics as a [distribution](https://docs.datadoghq.com/metrics/distributions/) which enables broader aggregations for percentiles (p50, p75, p90 etc).
+
+```typescript
+import { createLambdaExtensionClient } from 'seek-datadog-custom-metrics';
+
+// Expects `name` and `metrics` properties
+import config from '../config';
+
+// Returns a standard hot-shots StatsD instance
+const { metricsClient, withLambdaExtension } =
+  createLambdaExtensionClient(config);
+
+export const handler = withLambdaExtension(
+  (event: unknown, lambdaContext: LambdaContext) => {
+    try {
+      logger.info('request');
+
+      await lambdaFunction(event);
+    } catch (err) {
+      logger.error({ err }, 'request');
+
+      metricsClient.increment('invocation_error');
+
+      throw new Error('invoke error');
+    }
+  },
+);
 ```
 
 ### `createNoOpClient`

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ const metricsClient = createStatsDClient(StatsD, config, errorHandler);
 
 ### `createLambdaExtensionClient`
 
-`createLambdaExtensionClient` creates a [lambda extension](https://docs.datadoghq.com/serverless/libraries_integrations/extension/) client.
+`createLambdaExtensionClient` creates a [Lambda extension](https://docs.datadoghq.com/serverless/libraries_integrations/extension/) client.
 This is intended for AWS Lambda functions and is a replacement for `createCloudWatchClient`.
 
-This client will only submit metrics as a [distribution](https://docs.datadoghq.com/metrics/distributions/) which enables broader aggregations for percentiles (p50, p75, p90 etc).
+This client will only submit metrics as a [distribution](https://docs.datadoghq.com/metrics/distributions/) which enables globally accurate aggregations for percentiles (p50, p75, p90, etc).
 
 ```typescript
 import { createLambdaExtensionClient } from 'seek-datadog-custom-metrics';
@@ -76,7 +76,7 @@ const { metricsClient, withLambdaExtension } =
   createLambdaExtensionClient(config);
 
 export const handler = withLambdaExtension(
-  (event: unknown, lambdaContext: LambdaContext) => {
+  (event, _ctx) => {
     try {
       logger.info('request');
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:watch": "skuba test --watch"
   },
   "dependencies": {
-    "@types/aws-lambda": "8.10.108"
+    "@types/aws-lambda": "^8.10.108"
   },
   "devDependencies": {
     "@types/node": "16.18.12",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "test:ci": "skuba test --coverage",
     "test:watch": "skuba test --watch"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@types/aws-lambda": "8.10.108"
+  },
   "devDependencies": {
-    "@types/aws-lambda": "8.10.108",
     "@types/node": "16.18.12",
     "datadog-lambda-js": "6.84.0",
     "dd-trace": "3.9.3",

--- a/package.json
+++ b/package.json
@@ -32,15 +32,21 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@types/aws-lambda": "8.10.108",
     "@types/node": "16.18.12",
+    "datadog-lambda-js": "6.84.0",
     "dd-trace": "3.9.3",
     "hot-shots": "9.3.0",
     "skuba": "5.1.1"
   },
   "peerDependencies": {
+    "datadog-lambda-js": "6.x",
     "hot-shots": "6.x || 7.x || 8.x || 9.x"
   },
   "peerDependenciesMeta": {
+    "datadog-lambda-js": {
+      "optional": true
+    },
     "hot-shots": {
       "optional": true
     }

--- a/src/LambdaExtensionMetricsClient.ts
+++ b/src/LambdaExtensionMetricsClient.ts
@@ -1,6 +1,4 @@
 /**
- * TODO: Could just make this extend from the original MetricsClient 🤔.
- *
  * Abstract interface for recording metrics for AWS Lambda
  */
 export interface LambdaExtensionMetricsClient {

--- a/src/LambdaExtensionMetricsClient.ts
+++ b/src/LambdaExtensionMetricsClient.ts
@@ -38,21 +38,4 @@ export interface LambdaExtensionMetricsClient {
    * @param tags  - Optional list of tags for the metric.
    */
   increment(name: string, count: number, tags?: string[]): void;
-
-  /**
-   * Decrements a counter by one
-   *
-   * @param name  - Name of the metric to increment.
-   * @param tags  - Optional list of tags for the metric.
-   */
-  decrement(name: string, tags?: string[]): void;
-
-  /**
-   * Decrements a counter by the specified integer count
-   *
-   * @param name  - Name of the metric to increment.
-   * @param count - Number to decrement the counter by.
-   * @param tags  - Optional list of tags for the metric.
-   */
-  decrement(name: string, count: number, tags?: string[]): void;
 }

--- a/src/LambdaExtensionMetricsClient.ts
+++ b/src/LambdaExtensionMetricsClient.ts
@@ -1,0 +1,58 @@
+/**
+ * TODO: Could just make this extend from the original MetricsClient 🤔.
+ *
+ * Abstract interface for recording metrics for AWS Lambda
+ */
+export interface LambdaExtensionMetricsClient {
+  /**
+   * Records a time in milliseconds
+   *
+   * @param name  - Name of the metric to record.
+   * @param value - Time in milliseconds. Fractional values are supported.
+   * @param tags  - Optional list of tags for the metric.
+   */
+  timing(name: string, value: number, tags?: string[]): void;
+
+  /**
+   * Measures the statistical distribution of a set of values
+   *
+   * @param name  - Name of the metric to record.
+   * @param value - Value to include in the statistical distribution.
+   * @param tags  - Optional list of tags for the metric.
+   */
+  distribution(name: string, value: number, tags?: string[]): void;
+
+  /**
+   * Increments a counter by one
+   *
+   * @param name  - Name of the metric to increment.
+   * @param tags  - Optional list of tags for the metric.
+   */
+  increment(name: string, tags?: string[]): void;
+
+  /**
+   * Increments a counter by the specified integer count
+   *
+   * @param name  - Name of the metric to increment.
+   * @param count - Number to increment the counter by.
+   * @param tags  - Optional list of tags for the metric.
+   */
+  increment(name: string, count: number, tags?: string[]): void;
+
+  /**
+   * Decrements a counter by one
+   *
+   * @param name  - Name of the metric to increment.
+   * @param tags  - Optional list of tags for the metric.
+   */
+  decrement(name: string, tags?: string[]): void;
+
+  /**
+   * Decrements a counter by the specified integer count
+   *
+   * @param name  - Name of the metric to increment.
+   * @param count - Number to decrement the counter by.
+   * @param tags  - Optional list of tags for the metric.
+   */
+  decrement(name: string, count: number, tags?: string[]): void;
+}

--- a/src/createCloudWatchClient.ts
+++ b/src/createCloudWatchClient.ts
@@ -18,8 +18,7 @@ const sanitiseTag = (tag: string): string => tag.replace(/\||@|,/g, '_');
  * Creates a new CloudWatch Datadog client configured for the given app
  *
  * @deprecated This depends on Datadog's deprecated CloudWatch log integration.
- * This has been superseded by the Datadog Lambda Extension which does not
- * support the `count` metric type required by our `MetricClient` interface.
+ * Consumers should migrate to the `createLambdaExtensionClient` function.
  *
  * @see {@link https://docs.datadoghq.com/serverless/libraries_integrations/extension/}
  * @see {@link https://docs.datadoghq.com/serverless/custom_metrics/#deprecated-cloudwatch-logs}

--- a/src/createLambdaExtensionClient.test.ts
+++ b/src/createLambdaExtensionClient.test.ts
@@ -24,6 +24,17 @@ describe('createLambdaExtensionClient', () => {
 
       expect(datadog).toHaveBeenCalledTimes(1);
     });
+
+    it('should not call the `datadog` wrapper when metrics is turned off', () => {
+      const client = createLambdaExtensionClient({
+        name: 'test',
+        metrics: false,
+      });
+
+      client.withLambdaExtension(() => Promise.resolve({}));
+
+      expect(datadog).not.toHaveBeenCalled();
+    });
   });
 
   describe('timing', () => {

--- a/src/createLambdaExtensionClient.test.ts
+++ b/src/createLambdaExtensionClient.test.ts
@@ -117,26 +117,4 @@ describe('createLambdaExtensionClient', () => {
       );
     });
   });
-
-  describe('decrement', () => {
-    it('should decrement with an implicit value', () => {
-      metricsClient.decrement('my_custom_metric');
-
-      expect(sendDistributionMetric).toHaveBeenCalledTimes(1);
-      expect(sendDistributionMetric).toHaveBeenCalledWith(
-        'test.my_custom_metric',
-        -1,
-      );
-    });
-
-    it('should decrement with an explicit value', () => {
-      metricsClient.decrement('my_custom_metric', 10);
-
-      expect(sendDistributionMetric).toHaveBeenCalledTimes(1);
-      expect(sendDistributionMetric).toHaveBeenCalledWith(
-        'test.my_custom_metric',
-        -10,
-      );
-    });
-  });
 });

--- a/src/createLambdaExtensionClient.test.ts
+++ b/src/createLambdaExtensionClient.test.ts
@@ -1,0 +1,142 @@
+import * as datadogJS from 'datadog-lambda-js';
+
+import { createLambdaExtensionClient } from './createLambdaExtensionClient';
+
+const sendDistributionMetric = jest
+  .spyOn(datadogJS, 'sendDistributionMetric')
+  .mockReturnValue();
+
+const datadog = jest.spyOn(datadogJS, 'datadog').mockReturnValue(() => {});
+
+describe('createLambdaExtensionClient', () => {
+  const { metricsClient, withLambdaExtension } = createLambdaExtensionClient({
+    name: 'test',
+    metrics: true,
+  });
+
+  const tags = ['pipe|special|char', 'env:prod'];
+
+  afterEach(() => jest.resetAllMocks());
+
+  describe('withLambdaExtension', () => {
+    it('should call the `datadog` wrapper', () => {
+      withLambdaExtension(() => Promise.resolve({}));
+
+      expect(datadog).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('timing', () => {
+    it('should record integer timings without tags', () => {
+      metricsClient.timing('my_custom_metric', 100);
+
+      expect(sendDistributionMetric).toHaveBeenCalledTimes(1);
+      expect(sendDistributionMetric).toHaveBeenCalledWith(
+        'test.my_custom_metric',
+        100,
+      );
+    });
+
+    it('should record float timings with tags', () => {
+      metricsClient.timing('my_custom_metric', 1234.5, tags);
+
+      expect(sendDistributionMetric).toHaveBeenCalledTimes(1);
+      expect(sendDistributionMetric).toHaveBeenCalledWith(
+        'test.my_custom_metric',
+        1234.5,
+        'pipe_special_char',
+        'env:prod',
+      );
+    });
+  });
+
+  describe('distribution', () => {
+    it('should record integer values without tags', () => {
+      metricsClient.distribution('my_custom_metric', 100);
+
+      expect(sendDistributionMetric).toHaveBeenCalledTimes(1);
+      expect(sendDistributionMetric).toHaveBeenCalledWith(
+        'test.my_custom_metric',
+        100,
+      );
+    });
+
+    it('should record float values with tags', () => {
+      metricsClient.distribution('my_custom_metric', 1234.5, tags);
+
+      expect(sendDistributionMetric).toHaveBeenCalledTimes(1);
+      expect(sendDistributionMetric).toHaveBeenCalledWith(
+        'test.my_custom_metric',
+        1234.5,
+        'pipe_special_char',
+        'env:prod',
+      );
+    });
+  });
+
+  describe('increment', () => {
+    it('should increment with an implicit value and no tags', () => {
+      metricsClient.increment('my_custom_metric');
+
+      expect(sendDistributionMetric).toHaveBeenCalledTimes(1);
+      expect(sendDistributionMetric).toHaveBeenCalledWith(
+        'test.my_custom_metric',
+        1,
+      );
+    });
+
+    it('should increment with an implicit value and tags', () => {
+      metricsClient.increment('my_custom_metric', ['comma,special,char']);
+
+      expect(sendDistributionMetric).toHaveBeenCalledTimes(1);
+      expect(sendDistributionMetric).toHaveBeenCalledWith(
+        'test.my_custom_metric',
+        1,
+        'comma_special_char',
+      );
+    });
+
+    it('should increment with an explicit value and no tags', () => {
+      metricsClient.increment('my_custom_metric', 10);
+
+      expect(sendDistributionMetric).toHaveBeenCalledTimes(1);
+      expect(sendDistributionMetric).toHaveBeenCalledWith(
+        'test.my_custom_metric',
+        10,
+      );
+    });
+
+    it('should increment with an explicit value and tags', () => {
+      metricsClient.increment('my_custom_metric', 10, ['compound:tag']);
+
+      expect(sendDistributionMetric).toHaveBeenCalledTimes(1);
+      expect(sendDistributionMetric).toHaveBeenCalledWith(
+        'test.my_custom_metric',
+        10,
+        'compound:tag',
+      );
+    });
+  });
+
+  describe('decrement', () => {
+    it('should decrement with an implicit value', () => {
+      metricsClient.decrement('my_custom_metric');
+
+      expect(sendDistributionMetric).toHaveBeenCalledTimes(1);
+      expect(sendDistributionMetric).toHaveBeenCalledWith(
+        'test.my_custom_metric',
+        -1,
+      );
+    });
+
+    it('should decrement with an explicit value', () => {
+      metricsClient.decrement('my_custom_metric', 10);
+
+      expect(sendDistributionMetric).toHaveBeenCalledTimes(1);
+      expect(sendDistributionMetric).toHaveBeenCalledWith(
+        'test.my_custom_metric',
+        -10,
+      );
+    });
+  });
+});

--- a/src/createLambdaExtensionClient.ts
+++ b/src/createLambdaExtensionClient.ts
@@ -54,31 +54,24 @@ export const createLambdaExtensionClient = (
     }
   };
 
-  // This is used to implement `increment` and `decrement`
-  // `countToValue` is a hook to allow `decrement` to flip the sign of the count
+  const sendCount = (
+    name: string,
+    countOrTags?: number | string[],
+    tagsIfCount?: string[],
+  ): void => {
+    let count: number;
+    let tags: string[] | undefined;
 
-  // @TODO: Do we need `decrement`? We don't actually use it in Indirect at least.
-  const sendCount =
-    (countToValue: (value: number) => number) =>
-    (
-      name: string,
-      countOrTags?: number | string[],
-      tagsIfCount?: string[],
-    ): void => {
-      let count: number;
-      let tags: string[] | undefined;
+    if (typeof countOrTags === 'number') {
+      count = countOrTags;
+      tags = tagsIfCount;
+    } else {
+      count = 1;
+      tags = countOrTags;
+    }
 
-      // Emulate overloading from StatsD's interface
-      if (typeof countOrTags === 'number') {
-        count = countOrTags;
-        tags = tagsIfCount;
-      } else {
-        count = 1;
-        tags = countOrTags;
-      }
-
-      send({ name, tags, value: countToValue(count) });
-    };
+    send({ name, tags, value: count });
+  };
 
   return {
     /**
@@ -94,8 +87,7 @@ export const createLambdaExtensionClient = (
       config.metrics ? (datadog(fn) as Handler<Event, Output>) : fn,
 
     metricsClient: {
-      increment: sendCount((count) => count),
-      decrement: sendCount((count) => -count),
+      increment: sendCount,
 
       distribution: (name: string, value: number, tags?: string[]): void => {
         send({ name, tags, value });

--- a/src/createLambdaExtensionClient.ts
+++ b/src/createLambdaExtensionClient.ts
@@ -21,6 +21,12 @@ type Handler<Event, Output> = (
 
 interface LambdaExtensionClient {
   metricsClient: LambdaExtensionMetricsClient;
+  /**
+   * Conditionally wraps your AWS lambda handler function based on the provided config.
+   *
+   * This is necessary for initialising metrics/tracing support.
+   */
+  // This also "fixes" its broken type definitions.
   withLambdaExtension: <Event, Output = unknown>(
     fn: Handler<Event, Output>,
   ) => Handler<Event, Output>;
@@ -74,13 +80,6 @@ export const createLambdaExtensionClient = (
   };
 
   return {
-    /**
-     * TODO: Provide an description.
-     *
-     * Conditionally applies the Datadog wrapper to a Lambda handler.
-     *
-     * This also "fixes" its broken type definitions.
-     */
     withLambdaExtension: <Event, Output = unknown>(
       fn: Handler<Event, Output>,
     ): Handler<Event, Output> =>

--- a/src/createLambdaExtensionClient.ts
+++ b/src/createLambdaExtensionClient.ts
@@ -1,0 +1,109 @@
+import type { Context } from 'aws-lambda';
+import { datadog, sendDistributionMetric } from 'datadog-lambda-js';
+
+import { LambdaExtensionMetricsClient } from './LambdaExtensionMetricsClient';
+
+interface DatadogMetric {
+  name: string;
+  tags?: string[];
+  value: number;
+}
+
+interface DatadogConfig {
+  name: string;
+  metrics: boolean;
+}
+
+type Handler<Event, Output> = (
+  event: Event,
+  ctx: Readonly<Context>,
+) => Promise<Output>;
+
+interface LambdaExtensionClient {
+  metricsClient: LambdaExtensionMetricsClient;
+  withLambdaExtension: <Event, Output = unknown>(
+    fn: Handler<Event, Output>,
+  ) => Handler<Event, Output>;
+}
+
+/**
+ * Replaces tag special characters with an underscore
+ */
+const sanitiseTag = (tag: string): string => tag.replace(/\||@|,/g, '_');
+
+/**
+ * Creates a new Datadog Lambda client configured for the given app.
+ *
+ * @see {@link https://docs.datadoghq.com/serverless/libraries_integrations/extension/}
+ *
+ * @param config - Application configuration
+ */
+export const createLambdaExtensionClient = (
+  config: DatadogConfig,
+): LambdaExtensionClient => {
+  const send = (metric: DatadogMetric) => {
+    const { value } = metric;
+
+    const sanitisedLambdaName = config.name.replace(new RegExp('-', 'g'), '_');
+    const name = `${sanitisedLambdaName}.${metric.name.toLowerCase()}`;
+
+    const tags = (metric.tags || []).map(sanitiseTag);
+
+    if (config.metrics) {
+      sendDistributionMetric(name, value, ...tags);
+    }
+  };
+
+  // This is used to implement `increment` and `decrement`
+  // `countToValue` is a hook to allow `decrement` to flip the sign of the count
+
+  // @TODO: Do we need `decrement`? We don't actually use it in Indirect at least.
+  const sendCount =
+    (countToValue: (value: number) => number) =>
+    (
+      name: string,
+      countOrTags?: number | string[],
+      tagsIfCount?: string[],
+    ): void => {
+      let count: number;
+      let tags: string[] | undefined;
+
+      // Emulate overloading from StatsD's interface
+      if (typeof countOrTags === 'number') {
+        count = countOrTags;
+        tags = tagsIfCount;
+      } else {
+        count = 1;
+        tags = countOrTags;
+      }
+
+      send({ name, tags, value: countToValue(count) });
+    };
+
+  return {
+    /**
+     * TODO: Provide an description.
+     *
+     * Conditionally applies the Datadog wrapper to a Lambda handler.
+     *
+     * This also "fixes" its broken type definitions.
+     */
+    withLambdaExtension: <Event, Output = unknown>(
+      fn: Handler<Event, Output>,
+    ): Handler<Event, Output> =>
+      config.metrics ? (datadog(fn) as Handler<Event, Output>) : fn,
+
+    metricsClient: {
+      increment: sendCount((count) => count),
+      decrement: sendCount((count) => -count),
+
+      distribution: (name: string, value: number, tags?: string[]): void => {
+        send({ name, tags, value });
+      },
+
+      timing: (name: string, value: number, tags?: string[]): void => {
+        send({ name, tags, value });
+      },
+    },
+  };
+};

--- a/src/createTimedSpan.ts
+++ b/src/createTimedSpan.ts
@@ -1,5 +1,7 @@
 import { MetricsClient } from './MetricsClient';
 
+type TimingMetricsClient = Pick<MetricsClient, 'increment' | 'timing'>;
+
 /**
  * Sends timing related metrics for an asynchronous operation
  *
@@ -12,7 +14,7 @@ import { MetricsClient } from './MetricsClient';
  * @param block         - Function returning the promise to time
  */
 export const createTimedSpan =
-  (metricsClient: MetricsClient) =>
+  (metricsClient: TimingMetricsClient) =>
   async <T>(name: string, block: () => PromiseLike<T>): Promise<T> => {
     const startTime = process.hrtime.bigint();
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,6 @@
 import {
   createCloudWatchClient,
+  createLambdaExtensionClient,
   createNoOpClient,
   createStatsDClient,
   createTimedSpan,
@@ -13,6 +14,10 @@ describe('index', () => {
 
   it('should export a createCloudWatchClient function', () => {
     expect(createCloudWatchClient).toBeInstanceOf(Function);
+  });
+
+  it('should export a createLambdaExtensionClient function', () => {
+    expect(createLambdaExtensionClient).toBeInstanceOf(Function);
   });
 
   it('should export a createNoOpClient function', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { createCloudWatchClient } from './createCloudWatchClient';
+export { createLambdaExtensionClient } from './createLambdaExtensionClient';
 export { createNoOpClient } from './createNoOpClient';
 export { createStatsDClient } from './createStatsDClient';
 export { createTimedSpan } from './createTimedSpan';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,6 +1363,11 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
+"@types/aws-lambda@8.10.108":
+  version "8.10.108"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.108.tgz#ddadf0d9182f2f5e689ce5fc05b5f711fad6d115"
+  integrity sha512-1yh1W1WoqK3lGHy+V/Fi55zobxrDHUUsluCWdMlOXkCvtsCmHPXOG+CQ2STIL4B1g6xi6I6XzxaF8V9+zeIFLA==
+
 "@types/babel__core@^7.1.14":
   version "7.1.19"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.19.tgz#7b497495b7d1b4812bdb9d02804d0576f43ee460"
@@ -1910,6 +1915,11 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
   integrity sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==
 
+bignumber.js@^9.0.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.1.tgz#c4df7dc496bd849d4c9464344c1aa74228b4dac6"
+  integrity sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==
+
 bin-links@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/bin-links/-/bin-links-3.0.3.tgz#3842711ef3db2cd9f16a5f404a996a12db355a6e"
@@ -2398,6 +2408,17 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+datadog-lambda-js@6.84.0:
+  version "6.84.0"
+  resolved "https://registry.yarnpkg.com/datadog-lambda-js/-/datadog-lambda-js-6.84.0.tgz#3c402edb92c27fe1639d87403729ad1ad5f286a4"
+  integrity sha512-FSHIOT1btAJQlxW/8gXs28UyF0TDP2CEGgKLwB3/9rlIIiNpnK4anQRvru+w3waFDUGe9+tya/5lUomOBwMdUw==
+  dependencies:
+    bignumber.js "^9.0.1"
+    hot-shots "8.5.0"
+    promise-retry "^2.0.1"
+    serialize-error "^8.1.0"
+    shimmer "^1.2.1"
 
 date-fns@^2.29.1:
   version "2.29.3"
@@ -3556,6 +3577,13 @@ hosted-git-info@^6.0.0:
   integrity sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==
   dependencies:
     lru-cache "^7.5.1"
+
+hot-shots@8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/hot-shots/-/hot-shots-8.5.0.tgz#860246a3694dfb74cfe6045501eb59fb57e16eb9"
+  integrity sha512-GNXtNSxa9qibcPhi3gndyN5g14iBJS+/DDlu7hjSPfXYJy9/fcO13DgSyfPUVWrD/aIyPY36z7MksHvDe05zYg==
+  optionalDependencies:
+    unix-dgram "2.0.x"
 
 hot-shots@9.3.0:
   version "9.3.0"
@@ -6254,7 +6282,7 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-serialize-error@^8.0.1:
+serialize-error@^8.0.1, serialize-error@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-8.1.0.tgz#3a069970c712f78634942ddd50fbbc0eaebe2f67"
   integrity sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==
@@ -6290,6 +6318,11 @@ shell-quote@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
+
+shimmer@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
+  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -7053,7 +7086,7 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
-unix-dgram@2.x:
+unix-dgram@2.0.x, unix-dgram@2.x:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/unix-dgram/-/unix-dgram-2.0.6.tgz#6d567b0eb6d7a9504e561532b598a46e34c5968b"
   integrity sha512-AURroAsb73BZ6CdAyMrTk/hYKNj3DuYYEuOaB8bYMOHGKupRNScw90Q5C71tWJc3uE7dIeXRyuwN0xLLq3vDTg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,10 +1363,10 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
-"@types/aws-lambda@8.10.108":
-  version "8.10.108"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.108.tgz#ddadf0d9182f2f5e689ce5fc05b5f711fad6d115"
-  integrity sha512-1yh1W1WoqK3lGHy+V/Fi55zobxrDHUUsluCWdMlOXkCvtsCmHPXOG+CQ2STIL4B1g6xi6I6XzxaF8V9+zeIFLA==
+"@types/aws-lambda@^8.10.108":
+  version "8.10.114"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.114.tgz#4048273ebcd517dd118ecaa34b1368d275b6c7ad"
+  integrity sha512-M8WpEGfC9iQ6V2Ccq6nGIXoQgeVc6z0Ngk8yCOL5V/TYIxshvb0MWQYLFFTZDesL0zmsoBc4OBjG9DB/4rei6w==
 
 "@types/babel__core@^7.1.14":
   version "7.1.19"


### PR DESCRIPTION
This adds a new function to send metrics to Datadog. This is essentially a wrapper around `datadog-lambda-js` but is intended to follow a similar pattern with our existing metric clients. 

I've explicitly removed `decrement` for now as we don't leverage this in Indirect and therefore will only look to implement it if there's a need from other teams.

In regards to the comment about Datadog Lambda Extension not supporting the `count` metric type, this should be resolved by the fact that distribution metrics involve raw data that aren't aggregated on the agent. This means that we can still apply a `count` to the metrics for a given time interval. Refer to https://docs.datadoghq.com/metrics/types/?tab=distribution for an example. 