### PR TITLE
fix: Avoid hard `datadog-lambda-js` dependency

### DIFF
--- a/src/createLambdaExtensionClient.ts
+++ b/src/createLambdaExtensionClient.ts
@@ -1,5 +1,4 @@
 import type { Context } from 'aws-lambda';
-import { datadog, sendDistributionMetric } from 'datadog-lambda-js';
 
 import { LambdaExtensionMetricsClient } from './LambdaExtensionMetricsClient';
 
@@ -47,6 +46,10 @@ const sanitiseTag = (tag: string): string => tag.replace(/\||@|,/g, '_');
 export const createLambdaExtensionClient = (
   config: DatadogConfig,
 ): LambdaExtensionClient => {
+  const { datadog, sendDistributionMetric } =
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require('datadog-lambda-js') as typeof import('datadog-lambda-js');
+
   const send = (metric: DatadogMetric) => {
     const { value } = metric;
 


### PR DESCRIPTION
Fixes #196; see error in seek-oss/skuba#1128:

https://github.com/seek-oss/skuba/actions/runs/4465801340/jobs/7843220303#step:4:330