### PR TITLE
feat(createTimedSpan): Add an optional `afterCompletion` hook to pass back `latency`

### DIFF
--- a/src/createTimedSpan.test.ts
+++ b/src/createTimedSpan.test.ts
@@ -45,6 +45,27 @@ describe('timedSpan', () => {
     }
   });
 
+  it('should call afterCompletion', async () => {
+    jest.spyOn(metricsClient, 'increment');
+    jest.spyOn(metricsClient, 'timing');
+
+    let duration = 0;
+
+    const result = await timedSpan(
+      'test',
+      // This is false but we still successfully resolved
+      () => Promise.resolve(false),
+      (timedDuration) => {
+        duration = timedDuration;
+      },
+    );
+
+    expect(result).toBe(false);
+
+    // Hopefully this doesn't become flaky and end up as 0
+    expect(duration).toBeGreaterThan(0);
+  });
+
   it('should handle failure', async () => {
     const mockIncrement = jest.spyOn(metricsClient, 'increment');
     const mockTiming = jest.spyOn(metricsClient, 'timing');

--- a/src/createTimedSpan.ts
+++ b/src/createTimedSpan.ts
@@ -18,7 +18,7 @@ export const createTimedSpan =
   async <T>(
     name: string,
     block: () => PromiseLike<T>,
-    afterCompletion?: (duration: number) => void,
+    afterCompletion?: (duration: number, success: boolean) => void,
   ): Promise<T> => {
     const startTime = process.hrtime.bigint();
 
@@ -30,7 +30,7 @@ export const createTimedSpan =
       metricsClient.timing(`${name}.latency`, durationMilliseconds);
       metricsClient.increment(`${name}.count`, [successTag]);
 
-      afterCompletion?.(durationMilliseconds);
+      afterCompletion?.(durationMilliseconds, success);
     };
 
     try {

--- a/src/createTimedSpan.ts
+++ b/src/createTimedSpan.ts
@@ -15,15 +15,22 @@ type TimingMetricsClient = Pick<MetricsClient, 'increment' | 'timing'>;
  */
 export const createTimedSpan =
   (metricsClient: TimingMetricsClient) =>
-  async <T>(name: string, block: () => PromiseLike<T>): Promise<T> => {
+  async <T>(
+    name: string,
+    block: () => PromiseLike<T>,
+    afterCompletion?: (duration: number) => void,
+  ): Promise<T> => {
     const startTime = process.hrtime.bigint();
 
     const handleCompletion = (success: boolean) => {
       const durationNanos = process.hrtime.bigint() - startTime;
       const successTag = success ? 'success' : 'failure';
+      const durationMilliseconds = Number(durationNanos) / 1e6;
 
-      metricsClient.timing(`${name}.latency`, Number(durationNanos) / 1e6);
+      metricsClient.timing(`${name}.latency`, durationMilliseconds);
       metricsClient.increment(`${name}.count`, [successTag]);
+
+      afterCompletion?.(durationMilliseconds);
     };
 
     try {


### PR DESCRIPTION
This allows us to do something with the duration i.e. log it out with the associated request. I'm intending on adding this to `indie-shakira` so I can log out the associated IDs we're using when our queries are taking a while.