### PR TITLE
feat(createdTimedSpan): Add `tags`

### DIFF
--- a/src/createTimedSpan.test.ts
+++ b/src/createTimedSpan.test.ts
@@ -66,6 +66,30 @@ describe('timedSpan', () => {
     expect(duration).toBeGreaterThan(0);
   });
 
+  it('should pass along tags', async () => {
+    const mockIncrement = jest.spyOn(metricsClient, 'increment');
+    const mockTiming = jest.spyOn(metricsClient, 'timing');
+
+    await timedSpan(
+      'test',
+      // This is false but we still successfully resolved
+      () => Promise.resolve(false),
+      () => {},
+      ['new-tags'],
+    );
+
+    expect(mockIncrement).toHaveBeenCalledWith('test.count', [
+      'success',
+      'new-tags',
+    ]);
+
+    expect(mockTiming).toHaveBeenCalledWith(
+      'test.latency',
+      expect.any(Number),
+      ['new-tags'],
+    );
+  });
+
   it('should handle failure', async () => {
     const mockIncrement = jest.spyOn(metricsClient, 'increment');
     const mockTiming = jest.spyOn(metricsClient, 'timing');

--- a/src/createTimedSpan.ts
+++ b/src/createTimedSpan.ts
@@ -19,6 +19,7 @@ export const createTimedSpan =
     name: string,
     block: () => PromiseLike<T>,
     afterCompletion?: (duration: number, success: boolean) => void,
+    tags?: string[],
   ): Promise<T> => {
     const startTime = process.hrtime.bigint();
 
@@ -27,8 +28,8 @@ export const createTimedSpan =
       const successTag = success ? 'success' : 'failure';
       const durationMilliseconds = Number(durationNanos) / 1e6;
 
-      metricsClient.timing(`${name}.latency`, durationMilliseconds);
-      metricsClient.increment(`${name}.count`, [successTag]);
+      metricsClient.timing(`${name}.latency`, durationMilliseconds, tags);
+      metricsClient.increment(`${name}.count`, [successTag, ...(tags ?? [])]);
 
       afterCompletion?.(durationMilliseconds, success);
     };


### PR DESCRIPTION
This will allow us to propagate tags to Datadog. Following https://github.com/seek-oss/datadog-custom-metrics/pull/209, I've identified that the latency of one of our queries is being skewed due to synthetic testing. This will allow us to differentiate metrics from actual production partners to Ryanair.