### PR TITLE
feat(createTimedSpan): Pass along `tags` from `afterCompletion`

### DIFF
--- a/src/createTimedSpan.ts
+++ b/src/createTimedSpan.ts
@@ -2,6 +2,10 @@ import type { MetricsClient } from './MetricsClient';
 
 type TimingMetricsClient = Pick<MetricsClient, 'increment' | 'timing'>;
 
+interface AfterCompletion {
+  tags: string[];
+}
+
 /**
  * Sends timing related metrics for an asynchronous operation
  *
@@ -18,28 +22,40 @@ export const createTimedSpan =
   async <T>(
     name: string,
     block: () => PromiseLike<T>,
-    afterCompletion?: (duration: number, success: boolean) => void,
+    afterCompletion?: (
+      duration: number,
+      success: boolean,
+      result: T | undefined,
+    ) => AfterCompletion | void,
     tags?: string[],
   ): Promise<T> => {
     const startTime = process.hrtime.bigint();
 
-    const handleCompletion = (success: boolean) => {
+    const handleCompletion = (success: boolean, result: T | undefined) => {
       const durationNanos = process.hrtime.bigint() - startTime;
       const successTag = success ? 'success' : 'failure';
       const durationMilliseconds = Number(durationNanos) / 1e6;
 
-      metricsClient.timing(`${name}.latency`, durationMilliseconds, tags);
-      metricsClient.increment(`${name}.count`, [successTag, ...(tags ?? [])]);
+      const complete = afterCompletion?.(durationMilliseconds, success, result);
 
-      afterCompletion?.(durationMilliseconds, success);
+      const tagsToAdd =
+        tags || complete?.tags
+          ? [...(tags ?? []), ...(complete?.tags ?? [])]
+          : undefined;
+
+      metricsClient.timing(`${name}.latency`, durationMilliseconds, tagsToAdd);
+      metricsClient.increment(`${name}.count`, [
+        successTag,
+        ...(tagsToAdd ?? []),
+      ]);
     };
 
     try {
       const result = await block();
-      handleCompletion(true);
+      handleCompletion(true, result);
       return result;
     } catch (e) {
-      handleCompletion(false);
+      handleCompletion(false, undefined);
       throw e;
     }
   };


### PR DESCRIPTION
Building off of https://github.com/seek-oss/datadog-custom-metrics/pull/214, I want to be able to pass along tags on the basis of the results of the query. E.g. did we query a batch of applications versus just one application? This will allow us to separate metrics into different "buckets" and provide better understanding of how to set our thresholds.