### PR TITLE
fix(types): Allow null `metricsServer` and `version`

### DIFF
--- a/src/AppConfig.ts
+++ b/src/AppConfig.ts
@@ -13,10 +13,10 @@ export interface AppConfig {
   /**
    * Version of the application
    *
-   * This is used to tag custom metrics. It will typically be a CI build
-   * number.
+   * This is used to tag custom metrics. It will typically include a CI build
+   * number and/or a commit hash.
    */
-  version?: string;
+  version?: string | null | undefined;
 
   /**
    * Environment of the application

--- a/src/createStatsDClient.test.ts
+++ b/src/createStatsDClient.test.ts
@@ -12,4 +12,16 @@ describe('createStatsDClient', () => {
       }),
     ).toBeInstanceOf(Object);
   });
+
+  it('should handle null config values', () => {
+    expect(
+      createStatsDClient(StatsD, {
+        name: 'test',
+        environment: 'jest',
+        version: null,
+
+        metricsServer: null,
+      }),
+    ).toBeInstanceOf(Object);
+  });
 });

--- a/src/createStatsDClient.ts
+++ b/src/createStatsDClient.ts
@@ -44,10 +44,13 @@ export const createStatsDClient = <T extends InternalStatsD>(
   config: StatsDConfig,
   errorHandler?: (err: Error) => void,
 ): T => {
+  // istanbul ignore next: Jest is not picking up coalesce coverage
+  const host = config.metricsServer ?? undefined;
+
   const client = new StatsD({
     // Disable ourselves if there's no configured metrics server
     mock: !config.metricsServer,
-    host: config.metricsServer ?? undefined,
+    host,
     errorHandler,
 
     prefix: `${config.name}.`,

--- a/src/createStatsDClient.ts
+++ b/src/createStatsDClient.ts
@@ -26,7 +26,7 @@ export interface StatsDConfig extends AppConfig {
    * For Gantry this is `localhost`. If this is not specified then a mock
    * client will be constructed.
    */
-  metricsServer?: string;
+  metricsServer?: string | null | undefined;
 }
 
 /**
@@ -47,7 +47,7 @@ export const createStatsDClient = <T extends InternalStatsD>(
   const client = new StatsD({
     // Disable ourselves if there's no configured metrics server
     mock: !config.metricsServer,
-    host: config.metricsServer,
+    host: config.metricsServer ?? undefined,
     errorHandler,
 
     prefix: `${config.name}.`,


### PR DESCRIPTION
null can be nicer as an explicit "this is not set".

We've seen some issues where engineers unintentionally omit a config value in a deployed environment, then wonder why e.g. metrics are not working.